### PR TITLE
Do not throw during read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.2
+
+- Fix a bug where reading would throw if a file did not exist and `createIfNonExistent` was set to false
+
 ### 3.0.1
 
 - Fix some critical typos

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -11,7 +11,8 @@ describe('ConfigFile', function() {
   const fixtures = Path.join(__dirname, 'fixtures')
   const directory = Path.join(fixtures, 'ignored')
   const nonExistent = Path.join(directory, 'file-1')
-  const tempPath = Path.join(directory, 'temp-1')
+  const tempPath1 = Path.join(directory, 'temp-1')
+  const tempPath2 = Path.join(directory, 'temp-2')
   const configPath = Path.join(directory, 'config.json')
 
   beforeEach(async function() {
@@ -103,15 +104,24 @@ describe('ConfigFile', function() {
     })
 
     it('pretty prints by default', async function() {
-      await getConfigFile(tempPath, { some: 'thing' }, { createIfNonExistent: true })
-      expect(await FS.readFile(tempPath, 'utf8')).toBe('{\n  "some": "thing"\n}\n')
+      await getConfigFile(tempPath1, { some: 'thing' }, { createIfNonExistent: true })
+      expect(await FS.readFile(tempPath1, 'utf8')).toBe('{\n  "some": "thing"\n}\n')
     })
     it('can disable pretty printing if we tell it to', async function() {
-      await getConfigFile(tempPath, { some: 'thing' }, {
+      await getConfigFile(tempPath1, { some: 'thing' }, {
         prettyPrint: false,
         createIfNonExistent: true,
       })
-      expect(await FS.readFile(tempPath, 'utf8')).toBe('{"some":"thing"}\n')
+      expect(await FS.readFile(tempPath1, 'utf8')).toBe('{"some":"thing"}\n')
+    })
+    it('does not throw if file does not exist and createIfNonExistent is false', async function() {
+      const configFile = await getConfigFile(tempPath2, {
+        some: 'wow',
+      }, {
+        createIfNonExistent: false,
+      })
+      expect(await configFile.get()).toEqual({ some: 'wow' })
+      expect(await FS.exists(tempPath2)).toBe(false)
     })
   })
   describe('Async APIs', function() {
@@ -185,15 +195,24 @@ describe('ConfigFile', function() {
     })
 
     it('pretty prints by default', async function() {
-      await getConfigFile(tempPath, { some: 'thing' }, { createIfNonExistent: true })
-      expect(await FS.readFile(tempPath, 'utf8')).toBe('{\n  "some": "thing"\n}\n')
+      await getConfigFile(tempPath1, { some: 'thing' }, { createIfNonExistent: true })
+      expect(await FS.readFile(tempPath1, 'utf8')).toBe('{\n  "some": "thing"\n}\n')
     })
     it('can disable pretty printing if we tell it to', async function() {
-      await getConfigFile(tempPath, { some: 'thing' }, {
+      await getConfigFile(tempPath1, { some: 'thing' }, {
         prettyPrint: false,
         createIfNonExistent: true,
       })
-      expect(await FS.readFile(tempPath, 'utf8')).toBe('{"some":"thing"}\n')
+      expect(await FS.readFile(tempPath1, 'utf8')).toBe('{"some":"thing"}\n')
+    })
+    it('does not throw if file does not exist and createIfNonExistent is false', async function() {
+      const configFile = await getConfigFile(tempPath2, {
+        some: 'wow',
+      }, {
+        createIfNonExistent: false,
+      })
+      expect(configFile.getSync()).toEqual({ some: 'wow' })
+      expect(await FS.exists(tempPath2)).toBe(false)
     })
   })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -41,19 +41,35 @@ export function writeFileSync(filePath: string, contents: Object, config: Config
   }
 }
 
-export async function readFile(filePath: string, initialValue: Object): Promise<Object> {
-  const contents = stripBom(await FS.readFile(filePath, 'utf8'))
+export async function readFile(filePath: string, initialValue: Object, config: Config): Promise<Object> {
+  let contents
   try {
-    return Object.assign(initialValue, JSON.parse(contents))
+    contents = stripBom(await FS.readFile(filePath, 'utf8'))
+  } catch (error) {
+    if (error.code === 'ENOENT' && !config.createIfNonExistent) {
+      return Object.assign({}, initialValue)
+    }
+    throw error
+  }
+  try {
+    return Object.assign({}, initialValue, JSON.parse(contents))
   } catch (_) {
     throw new Error(`Invalid JSON found at '${filePath}'`)
   }
 }
 
-export function readFileSync(filePath: string, initialValue: Object): Object {
-  const contents = stripBom(FS.readFileSync(filePath, 'utf8'))
+export function readFileSync(filePath: string, initialValue: Object, config: Config): Object {
+  let contents
   try {
-    return Object.assign(initialValue, JSON.parse(contents))
+    contents = stripBom(FS.readFileSync(filePath, 'utf8'))
+  } catch (error) {
+    if (error.code === 'ENOENT' && !config.createIfNonExistent) {
+      return Object.assign({}, initialValue)
+    }
+    throw error
+  }
+  try {
+    return Object.assign({}, initialValue, JSON.parse(contents))
   } catch (_) {
     throw new Error(`Invalid JSON found at '${filePath}'`)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,10 @@ class ConfigFile {
     this.initialValue = initialValue
   }
   async get(key: string = '', defaultValue: any = null): any {
-    return this._get(key, defaultValue, await Helpers.readFile(this.filePath, this.initialValue))
+    return this._get(key, defaultValue, await Helpers.readFile(this.filePath, this.initialValue, this.config))
   }
   getSync(key: string = '', defaultValue: any = null): any {
-    return this._get(key, defaultValue, Helpers.readFileSync(this.filePath, this.initialValue))
+    return this._get(key, defaultValue, Helpers.readFileSync(this.filePath, this.initialValue, this.config))
   }
   _get(key: string, defaultValue: any, contents: Object): any {
     try {
@@ -37,10 +37,10 @@ class ConfigFile {
     }
   }
   async set(key: string, value: any, strict: boolean = false) {
-    await Helpers.writeFile(this.filePath, this._set(key, value, strict, await Helpers.readFile(this.filePath, this.initialValue)), this.config)
+    await Helpers.writeFile(this.filePath, this._set(key, value, strict, await Helpers.readFile(this.filePath, this.initialValue, this.config)), this.config)
   }
   setSync(key: string, value: any, strict: boolean = false) {
-    Helpers.writeFileSync(this.filePath, this._set(key, value, strict, Helpers.readFileSync(this.filePath, this.initialValue)), this.config)
+    Helpers.writeFileSync(this.filePath, this._set(key, value, strict, Helpers.readFileSync(this.filePath, this.initialValue, this.config)), this.config)
   }
   _set(key: string, value: any, strict: boolean = false, contents: Object) {
     const { childKey, parentKey } = ObjectPath.getKeys(key)
@@ -57,10 +57,10 @@ class ConfigFile {
     return contents
   }
   async delete(key: string, strict: boolean = false) {
-    await Helpers.writeFile(this.filePath, this._delete(key, strict, await Helpers.readFile(this.filePath, this.initialValue)), this.config)
+    await Helpers.writeFile(this.filePath, this._delete(key, strict, await Helpers.readFile(this.filePath, this.initialValue, this.config)), this.config)
   }
   deleteSync(key: string, strict: boolean = false) {
-    Helpers.writeFileSync(this.filePath, this._delete(key, strict, Helpers.readFileSync(this.filePath, this.initialValue)), this.config)
+    Helpers.writeFileSync(this.filePath, this._delete(key, strict, Helpers.readFileSync(this.filePath, this.initialValue, this.config)), this.config)
   }
   _delete(key: string, strict: boolean = false, contents: Object) {
     const { childKey, parentKey } = ObjectPath.getKeys(key)
@@ -69,10 +69,10 @@ class ConfigFile {
     return contents
   }
   async append(key: string, value: any, strict: boolean = false) {
-    await Helpers.writeFile(this.filePath, this._append(key, value, strict, await Helpers.readFile(this.filePath, this.initialValue)), this.config)
+    await Helpers.writeFile(this.filePath, this._append(key, value, strict, await Helpers.readFile(this.filePath, this.initialValue, this.config)), this.config)
   }
   appendSync(key: string, value: any, strict: boolean = false) {
-    Helpers.writeFileSync(this.filePath, this._append(key, value, strict, Helpers.readFileSync(this.filePath, this.initialValue)), this.config)
+    Helpers.writeFileSync(this.filePath, this._append(key, value, strict, Helpers.readFileSync(this.filePath, this.initialValue, this.config)), this.config)
   }
   _append(key: string, value: any, strict: boolean = false, contents: Object) {
     const parent = ObjectPath.deepNormalize(contents, ObjectPath.split(key), strict)


### PR DESCRIPTION
If `createIfNonExistent` is set to false, it should not throw on any read op